### PR TITLE
Fixed gettext for format strings without variables

### DIFF
--- a/flask_babelex/__init__.py
+++ b/flask_babelex/__init__.py
@@ -531,7 +531,10 @@ class Domain(object):
             gettext(u'Hello %(name)s!', name='World')
         """
         t = self.get_translations()
-        return t.ugettext(string) % variables
+        if variables:
+            return t.ugettext(string) % variables
+        else:
+            return t.ugettext(string)
 
     def ngettext(self, singular, plural, num, **variables):
         """Translates a string with the current locale and passes in the


### PR DESCRIPTION
Fixed issue when using with gettext with format strings without values